### PR TITLE
chore(package): update lodash to version 4.17.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased](https://github.com/eps1lon/poe-mods/compare/v1.9.0...HEAD)
 
+### Changed
+- Bumped `lodash` dependency to `^4.17.10` which fixes a security invulnerability.
+  ([#64](https://github.com/eps1lon/poe-mods/pull/64))
+
 ## [1.9.0](https://github.com/eps1lon/poe-mods/compare/v1.8.0...v1.9.0) (2018-05-30)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "typescript": "^2.7.1"
   },
   "dependencies": {
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "make-error": "^1.3.3"
   },
   "jest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2117,7 +2117,7 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
-lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.17.5:
+lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 


### PR DESCRIPTION
All versions before 4.17.5 had a security vulnerability via__proto__ pollution.