### PR TITLE
fix: bestiary mods being considered implicits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 
 ## [Unreleased](https://github.com/eps1lon/poe-mods/compare/v1.12.0...HEAD)
+### Fixed
+- `BestiaryMods` being considered implicts. ([#85](https://github.com/eps1lon/poe-mods/pull/85))
 
 ## [1.12.0](https://github.com/eps1lon/poe-mods/compare/v1.11.0...v1.12.0) (2018-06-24)
 ### Added

--- a/src/generators/__tests__/__snapshots__/mod_types.ts.snap
+++ b/src/generators/__tests__/__snapshots__/mod_types.ts.snap
@@ -2,10 +2,10 @@
 
 exports[`should match the curated list of Bestiary Aspect mods 1`] = `
 Array [
-  "GrantsCatAspect1",
-  "GrantsBirdAspect1_",
-  "GrantsSpiderAspect1",
-  "GrantsCrabAspect1_",
+  "GrantsCatAspectCrafted",
+  "GrantsBirdAspectCrafted",
+  "GrantsSpiderAspectCrafted",
+  "GrantsCrabAspectCrafted",
 ]
 `;
 

--- a/src/generators/mod_types/BestiaryAspectMods.ts
+++ b/src/generators/mod_types/BestiaryAspectMods.ts
@@ -12,10 +12,10 @@ export default class BestiaryAspectMods extends ViewOnlyOrb {
    * list of mod ids that can be crafted with Spirit Beasts
    */
   public static readonly ASPECT_MODS: Set<Mod['props']['id']> = new Set([
-    'GrantsCatAspect1',
-    'GrantsBirdAspect1_',
-    'GrantsSpiderAspect1',
-    'GrantsCrabAspect1_',
+    'GrantsCatAspectCrafted',
+    'GrantsBirdAspectCrafted',
+    'GrantsSpiderAspectCrafted',
+    'GrantsCrabAspectCrafted',
   ]);
 
   public static build(mods: ModProps[]): BestiaryAspectMods {

--- a/src/generators/mod_types/__tests__/BestiaryAspectMods.ts
+++ b/src/generators/mod_types/__tests__/BestiaryAspectMods.ts
@@ -7,10 +7,13 @@ it('ignores internal spawnweights', () => {
   const item = items.fromName('Iron Greaves');
   const generator = BestiaryAspectMods.build(mods.all());
 
-  expect(generator.modsFor(item).length).toBeGreaterThan(0);
+  const bestiaryMods = generator.modsFor(item, ['domain_full']);
+
+  expect(bestiaryMods.length).toBeGreaterThan(0);
   expect(
-    generator
-      .modsFor(item, ['domain_full'])
-      .map(({ mod, ...details }) => ({ mod: mod.props.id, ...details })),
+    bestiaryMods.map(({ mod, ...details }) => ({
+      mod: mod.props.id,
+      ...details,
+    })),
   ).toMatchSnapshot();
 });

--- a/src/generators/mod_types/__tests__/__snapshots__/BestiaryAspectMods.ts.snap
+++ b/src/generators/mod_types/__tests__/__snapshots__/BestiaryAspectMods.ts.snap
@@ -6,41 +6,41 @@ Array [
     "applicable": Object {
       "above_lld_level": false,
       "already_present": false,
-      "domain_full": false,
+      "domain_full": true,
       "lower_ilvl": false,
       "wrong_domain": false,
     },
-    "mod": "GrantsCatAspect1",
+    "mod": "GrantsCatAspectCrafted",
   },
   Object {
     "applicable": Object {
       "above_lld_level": false,
       "already_present": false,
-      "domain_full": false,
+      "domain_full": true,
       "lower_ilvl": false,
       "wrong_domain": false,
     },
-    "mod": "GrantsBirdAspect1_",
+    "mod": "GrantsBirdAspectCrafted",
   },
   Object {
     "applicable": Object {
       "above_lld_level": false,
       "already_present": false,
-      "domain_full": false,
+      "domain_full": true,
       "lower_ilvl": false,
       "wrong_domain": false,
     },
-    "mod": "GrantsSpiderAspect1",
+    "mod": "GrantsSpiderAspectCrafted",
   },
   Object {
     "applicable": Object {
       "above_lld_level": false,
       "already_present": false,
-      "domain_full": false,
+      "domain_full": true,
       "lower_ilvl": false,
       "wrong_domain": false,
     },
-    "mod": "GrantsCrabAspect1_",
+    "mod": "GrantsCrabAspectCrafted",
   },
 ]
 `;


### PR DESCRIPTION
Accidentally used the mod ids from the unique items